### PR TITLE
Updated key to avoid collisions at time zero

### DIFF
--- a/src/components/timeCodes.tsx
+++ b/src/components/timeCodes.tsx
@@ -74,7 +74,7 @@ export const TimeCodes: React.FC<Props> = ({
 
         return (
           <TimeCodeItem
-            key={fromMs}
+            key={`${fromMs}-${description}`}
             trackWidth={trackWidth}
             label={description}
             maxTime={max}


### PR DESCRIPTION
Using just `fromMs` as a key will end up in `0` being a key when time = 0. This is likely to cause a key collision.